### PR TITLE
Update python_version 3.13

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,20 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 
+# By default, run each hook only in the standard pre-commit stage
+default_install_hook_types: [pre-commit, commit-msg]
+default_stages: [pre-commit]
+
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.0.0
+    rev: v4.1.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v5.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -23,7 +27,7 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.6
+    rev: v0.11.7
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
@@ -33,13 +37,18 @@ repos:
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
+  - repo: https://github.com/phantomcyber/soar-app-linter
+    rev: 0.1.0
+    hooks:
+      - id: soar-app-linter
+        args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
     rev: 0.7.22
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.107.0
+    rev: v1.89.0
     hooks:
       - id: semgrep
   - repo: https://github.com/Yelp/detect-secrets
@@ -51,7 +60,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.0.0
+    rev: v2.0.9
     hooks:
       - id: build-docs
         language: python

--- a/ciscoesa.json
+++ b/ciscoesa.json
@@ -18,7 +18,7 @@
     "latest_tested_versions": [
         "Cisco Secure Email Gateway Virtual C100V Version: 14.2.0-620"
     ],
-    "python_version": "3",
+    "python_version": "3.9, 3.13",
     "fips_compliant": true,
     "configuration": {
         "url": {

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * chore(ci): update pre-commit config
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13
- Replace `.pre-commit-config.yaml` with latest template from dev-cicd-tools

[_Created by Sourcegraph batch change `grokas-splunk/002-update-python-versions-3.13-2.0`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/002-update-python-versions-3.13-2.0)